### PR TITLE
fix/(docs/switch): Refactor tailwindcss class to show scrollbar to see the overflowing content

### DIFF
--- a/apps/docs/components/bg-grid-container.tsx
+++ b/apps/docs/components/bg-grid-container.tsx
@@ -30,7 +30,7 @@ export const BgGridContainer: FC<BgGridContainerProps> = ({
         className,
       )}
     >
-      <div className="max-w-full py-4 px-2 w-full h-full scrollbar-hide overflow-x-scroll">
+      <div className="max-w-full py-4 px-2 w-full h-full overflow-x-auto">
         {children}
       </div>
       {/* <div


### PR DESCRIPTION
Refactored BgGridContainer component layout. The scrollbar was hidden in a  overflowing container which was hiding the content. To make the content scrollable made the change.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description
- In this page https://nextui.org/docs/components/switch in 'colors' section the overflowing content is hidden. The scrollbar is also hidden.  


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying
- The current behaviour is that the content overflowing is hidden. The scrollbar is also hidden.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds
- The tailwind css classes are modied to make the overflowing content visible with the help of the scrollbar.


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
- No
## 📝 Additional Information

![Screenshot 2023-11-27 at 11 34 59 AM](https://github.com/Mriganka5137/nextui/assets/105497106/9bade593-2247-4c18-a1ce-3811055374a2)

![Screenshot 2023-11-27 at 11 35 16 AM](https://github.com/Mriganka5137/nextui/assets/105497106/0a44852e-5626-4433-8506-9966b4ef1c15)
